### PR TITLE
feat: TLV support

### DIFF
--- a/proxy-protocol.txt
+++ b/proxy-protocol.txt
@@ -33,7 +33,7 @@ Revision history
                 reserved TLV type ranges, added TLV documentation, clarified
                 string encoding. With contributions from Andriy Palamarchuk
                 (Amazon.com).
-   2020/03/05 - added the unique ID TLV type (Tim DÃ¼sterhus)
+   2020/03/05 - added the unique ID TLV type (Tim Düsterhus)
 
 
 1. Background

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,15 +191,15 @@ mod parse_tests {
         assert!(!buf.has_remaining()); // Consume the ENTIRE header!
 
         fn valid_v4(
-            (a, b, c, d): (u8, u8, u8, u8),
-            e: u16,
-            (f, g, h, i): (u8, u8, u8, u8),
-            j: u16,
+            (s0, s1, s2, s3): (u8, u8, u8, u8),
+            sp: u16,
+            (d0, d1, d2, d3): (u8, u8, u8, u8),
+            dp: u16,
         ) -> ProxyHeader {
             ProxyHeader::Version1 {
                 addresses: version1::ProxyAddresses::Ipv4 {
-                    source: SocketAddrV4::new(Ipv4Addr::new(a, b, c, d), e),
-                    destination: SocketAddrV4::new(Ipv4Addr::new(f, g, h, i), j),
+                    source: SocketAddrV4::new(Ipv4Addr::new(s0, s1, s2, s3), sp),
+                    destination: SocketAddrV4::new(Ipv4Addr::new(d0, d1, d2, d3), dp),
                 },
             }
         }
@@ -223,15 +223,25 @@ mod parse_tests {
         );
 
         fn valid_v6(
-            (a, b, c, d, e, f, g, h): (u16, u16, u16, u16, u16, u16, u16, u16),
-            i: u16,
-            (j, k, l, m, n, o, p, q): (u16, u16, u16, u16, u16, u16, u16, u16),
-            r: u16,
+            (s0, s1, s2, s3, s4, s5, s6, s7): (u16, u16, u16, u16, u16, u16, u16, u16),
+            sp: u16,
+            (d0, d1, d2, d3, d4, d5, d6, d7): (u16, u16, u16, u16, u16, u16, u16, u16),
+            dp: u16,
         ) -> ProxyHeader {
             ProxyHeader::Version1 {
                 addresses: version1::ProxyAddresses::Ipv6 {
-                    source: SocketAddrV6::new(Ipv6Addr::new(a, b, c, d, e, f, g, h), i, 0, 0),
-                    destination: SocketAddrV6::new(Ipv6Addr::new(j, k, l, m, n, o, p, q), r, 0, 0),
+                    source: SocketAddrV6::new(
+                        Ipv6Addr::new(s0, s1, s2, s3, s4, s5, s6, s7),
+                        sp,
+                        0,
+                        0,
+                    ),
+                    destination: SocketAddrV6::new(
+                        Ipv6Addr::new(d0, d1, d2, d3, d4, d5, d6, d7),
+                        dp,
+                        0,
+                        0,
+                    ),
                 },
             }
         }
@@ -313,7 +323,7 @@ mod parse_tests {
             0x49,
             0x54,
             0x0A,
-            (2 << 4) | 0,
+            2 << 4,
         ];
         const PREFIX_PROXY: [u8; 13] = [
             0x0D,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,6 +639,9 @@ mod parse_tests {
                         // 3 bytes is clearly too few if we expect 2 IPv4s and ports
                         0,
                         3,
+                        0,
+                        0,
+                        0,
                     ][..],
                 ]
                 .concat()

--- a/src/version1.rs
+++ b/src/version1.rs
@@ -190,9 +190,7 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
         _ => unreachable!(),
     };
 
-    Ok(super::ProxyHeader::Version1 {
-        addresses,
-    })
+    Ok(super::ProxyHeader::Version1 { addresses })
 }
 
 pub(crate) fn encode(addresses: ProxyAddresses) -> Result<BytesMut, EncodeError> {
@@ -278,15 +276,15 @@ mod parse_tests {
     #[test]
     fn test_valid_ipv4_cases() {
         fn valid(
-            (a, b, c, d): (u8, u8, u8, u8),
-            e: u16,
-            (f, g, h, i): (u8, u8, u8, u8),
-            j: u16,
+            (s0, s1, s2, s3): (u8, u8, u8, u8),
+            sp: u16,
+            (d0, d1, d2, d3): (u8, u8, u8, u8),
+            dp: u16,
         ) -> ProxyHeader {
             ProxyHeader::Version1 {
                 addresses: ProxyAddresses::Ipv4 {
-                    source: SocketAddrV4::new(Ipv4Addr::new(a, b, c, d), e),
-                    destination: SocketAddrV4::new(Ipv4Addr::new(f, g, h, i), j),
+                    source: SocketAddrV4::new(Ipv4Addr::new(s0, s1, s2, s3), sp),
+                    destination: SocketAddrV4::new(Ipv4Addr::new(d0, d1, d2, d3), dp),
                 },
             }
         }
@@ -312,15 +310,25 @@ mod parse_tests {
     #[test]
     fn test_valid_ipv6_cases() {
         fn valid(
-            (a, b, c, d, e, f, g, h): (u16, u16, u16, u16, u16, u16, u16, u16),
-            i: u16,
-            (j, k, l, m, n, o, p, q): (u16, u16, u16, u16, u16, u16, u16, u16),
-            r: u16,
+            (s0, s1, s2, s3, s4, s5, s6, s7): (u16, u16, u16, u16, u16, u16, u16, u16),
+            sp: u16,
+            (d0, d1, d2, d3, d4, d5, d6, d7): (u16, u16, u16, u16, u16, u16, u16, u16),
+            dp: u16,
         ) -> ProxyHeader {
             ProxyHeader::Version1 {
                 addresses: ProxyAddresses::Ipv6 {
-                    source: SocketAddrV6::new(Ipv6Addr::new(a, b, c, d, e, f, g, h), i, 0, 0),
-                    destination: SocketAddrV6::new(Ipv6Addr::new(j, k, l, m, n, o, p, q), r, 0, 0),
+                    source: SocketAddrV6::new(
+                        Ipv6Addr::new(s0, s1, s2, s3, s4, s5, s6, s7),
+                        sp,
+                        0,
+                        0,
+                    ),
+                    destination: SocketAddrV6::new(
+                        Ipv6Addr::new(d0, d1, d2, d3, d4, d5, d6, d7),
+                        dp,
+                        0,
+                        0,
+                    ),
                 },
             }
         }

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -733,7 +733,7 @@ mod encode_tests {
                 ProxyTransportProtocol::Unspec,
                 ProxyAddresses::Unspec,
             ),
-            signed(&[(2 << 4) | 0, 0, 0, 0][..]),
+            signed(&[2 << 4, 0, 0, 0][..]),
         );
 
         assert_eq!(
@@ -756,7 +756,7 @@ mod encode_tests {
             signed(
                 &[
                     (2 << 4) | 1,
-                    (1 << 4) | 0,
+                    1 << 4,
                     0,
                     12,
                     1,
@@ -819,7 +819,7 @@ mod encode_tests {
             ),
             signed(
                 &[
-                    (2 << 4) | 0,
+                    2 << 4,
                     (1 << 4) | 2,
                     0,
                     12,
@@ -863,7 +863,7 @@ mod encode_tests {
             ),
             signed(
                 &[
-                    (2 << 4) | 0,
+                    2 << 4,
                     (2 << 4) | 2,
                     0,
                     36,


### PR DESCRIPTION
I added support for TLV extensions, as documented in proxy-protocol.txt

Comes with tests.
This will be a version bump, because the Version2 struct now has extra fields.

(FWIW, I think switching the parse side from an "impl Buf" to either Bytes or &[u8] slices (since we probably don't need to support discontinuous data) would make the implementation better by allowing to pass subslices instead of having to add len arguments. But I didn't add that API change.)

Closes #5.