### PR TITLE
Tighten dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ documentation = "https://docs.rs/proxy-protocol/"
 repository = "https://github.com/Proximyst/proxy-protocol.git"
 
 [dependencies]
-snafu = "~0.6"
-bytes = "~1"
+snafu = "0.6.9"
+bytes = "1"
 
 [dev-dependencies]
 pretty_assertions = "^0.7"
-rand = "~0.8"
+rand = "0.8"
 
 [features]
 default = []


### PR DESCRIPTION
This is a small change to ensure the crate properly depends on the snafu features it needs.

Don't use tilde requirements unnecessarily, and ensure things build
when resolving dependencies to minimal versions.

Checked with:

    cargo +nightly update -Z minimal-versions; cargo check