### PR TITLE
Fix EOF panics

### DIFF
--- a/src/version1.rs
+++ b/src/version1.rs
@@ -175,6 +175,8 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
     buf.advance(count);
 
     ensure!(buf.get_u8() == CR, IllegalHeaderEnding);
+    // We only checked up to the CR
+    ensure!(buf.remaining() >= 1, UnexpectedEof);
     ensure!(buf.get_u8() == LF, IllegalHeaderEnding);
 
     let addresses = match (source, destination) {

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -142,7 +142,7 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
                 needs: 108usize * 2,
             },
         );
-        ensure!(buf.remaining() >= 108 * 2, UnexpectedEof);
+        ensure!(buf.remaining() >= length, UnexpectedEof);
         let mut source = [0u8; 108];
         let mut destination = [0u8; 108];
         buf.copy_to_slice(&mut source[..]);
@@ -177,7 +177,7 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
         },
     );
     ensure!(
-        buf.remaining() >= port_length + address_length,
+        buf.remaining() >= length,
         UnexpectedEof,
     );
 


### PR DESCRIPTION
I found a couple rare EOF panics.

v1 = We only check up to the last CR but if LF is cut off we panic.

v2 = The TLV TODO was advancing the buffer beyond where it has been ensured (they were previously ensured only past the known lengths (which it compares the length against) but not the TLV lengths (which is length - known_length)