### PR TITLE
Refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,12 @@ documentation = "https://docs.rs/proxy-protocol/"
 repository = "https://github.com/Proximyst/proxy-protocol.git"
 
 [dependencies]
-snafu = "~0.6"
+snafu = "~0.8"
 bytes = "~1"
 
 [dev-dependencies]
-pretty_assertions = "^0.7"
-rand = "~0.8"
+pretty_assertions = "^1.4"
+rand = "~0.9"
 
 [features]
 default = []

--- a/proxy-protocol.txt
+++ b/proxy-protocol.txt
@@ -33,7 +33,7 @@ Revision history
                 reserved TLV type ranges, added TLV documentation, clarified
                 string encoding. With contributions from Andriy Palamarchuk
                 (Amazon.com).
-   2020/03/05 - added the unique ID TLV type (Tim DÃ¼sterhus)
+   2020/03/05 - added the unique ID TLV type (Tim Düsterhus)
 
 
 1. Background

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,15 +191,15 @@ mod parse_tests {
         assert!(!buf.has_remaining()); // Consume the ENTIRE header!
 
         fn valid_v4(
-            (a, b, c, d): (u8, u8, u8, u8),
-            e: u16,
-            (f, g, h, i): (u8, u8, u8, u8),
-            j: u16,
+            (s0, s1, s2, s3): (u8, u8, u8, u8),
+            sp: u16,
+            (d0, d1, d2, d3): (u8, u8, u8, u8),
+            dp: u16,
         ) -> ProxyHeader {
             ProxyHeader::Version1 {
                 addresses: version1::ProxyAddresses::Ipv4 {
-                    source: SocketAddrV4::new(Ipv4Addr::new(a, b, c, d), e),
-                    destination: SocketAddrV4::new(Ipv4Addr::new(f, g, h, i), j),
+                    source: SocketAddrV4::new(Ipv4Addr::new(s0, s1, s2, s3), sp),
+                    destination: SocketAddrV4::new(Ipv4Addr::new(d0, d1, d2, d3), dp),
                 },
             }
         }
@@ -223,15 +223,25 @@ mod parse_tests {
         );
 
         fn valid_v6(
-            (a, b, c, d, e, f, g, h): (u16, u16, u16, u16, u16, u16, u16, u16),
-            i: u16,
-            (j, k, l, m, n, o, p, q): (u16, u16, u16, u16, u16, u16, u16, u16),
-            r: u16,
+            (s0, s1, s2, s3, s4, s5, s6, s7): (u16, u16, u16, u16, u16, u16, u16, u16),
+            sp: u16,
+            (d0, d1, d2, d3, d4, d5, d6, d7): (u16, u16, u16, u16, u16, u16, u16, u16),
+            dp: u16,
         ) -> ProxyHeader {
             ProxyHeader::Version1 {
                 addresses: version1::ProxyAddresses::Ipv6 {
-                    source: SocketAddrV6::new(Ipv6Addr::new(a, b, c, d, e, f, g, h), i, 0, 0),
-                    destination: SocketAddrV6::new(Ipv6Addr::new(j, k, l, m, n, o, p, q), r, 0, 0),
+                    source: SocketAddrV6::new(
+                        Ipv6Addr::new(s0, s1, s2, s3, s4, s5, s6, s7),
+                        sp,
+                        0,
+                        0,
+                    ),
+                    destination: SocketAddrV6::new(
+                        Ipv6Addr::new(d0, d1, d2, d3, d4, d5, d6, d7),
+                        dp,
+                        0,
+                        0,
+                    ),
                 },
             }
         }
@@ -313,7 +323,7 @@ mod parse_tests {
             0x49,
             0x54,
             0x0A,
-            (2 << 4) | 0,
+            2 << 4,
         ];
         const PREFIX_PROXY: [u8; 13] = [
             0x0D,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,6 +639,9 @@ mod parse_tests {
                         // 3 bytes is clearly too few if we expect 2 IPv4s and ports
                         0,
                         3,
+                        0,
+                        0,
+                        0,
                     ][..],
                 ]
                 .concat()

--- a/src/version1.rs
+++ b/src/version1.rs
@@ -190,9 +190,7 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
         _ => unreachable!(),
     };
 
-    Ok(super::ProxyHeader::Version1 {
-        addresses,
-    })
+    Ok(super::ProxyHeader::Version1 { addresses })
 }
 
 pub(crate) fn encode(addresses: ProxyAddresses) -> Result<BytesMut, EncodeError> {
@@ -278,15 +276,15 @@ mod parse_tests {
     #[test]
     fn test_valid_ipv4_cases() {
         fn valid(
-            (a, b, c, d): (u8, u8, u8, u8),
-            e: u16,
-            (f, g, h, i): (u8, u8, u8, u8),
-            j: u16,
+            (s0, s1, s2, s3): (u8, u8, u8, u8),
+            sp: u16,
+            (d0, d1, d2, d3): (u8, u8, u8, u8),
+            dp: u16,
         ) -> ProxyHeader {
             ProxyHeader::Version1 {
                 addresses: ProxyAddresses::Ipv4 {
-                    source: SocketAddrV4::new(Ipv4Addr::new(a, b, c, d), e),
-                    destination: SocketAddrV4::new(Ipv4Addr::new(f, g, h, i), j),
+                    source: SocketAddrV4::new(Ipv4Addr::new(s0, s1, s2, s3), sp),
+                    destination: SocketAddrV4::new(Ipv4Addr::new(d0, d1, d2, d3), dp),
                 },
             }
         }
@@ -312,15 +310,25 @@ mod parse_tests {
     #[test]
     fn test_valid_ipv6_cases() {
         fn valid(
-            (a, b, c, d, e, f, g, h): (u16, u16, u16, u16, u16, u16, u16, u16),
-            i: u16,
-            (j, k, l, m, n, o, p, q): (u16, u16, u16, u16, u16, u16, u16, u16),
-            r: u16,
+            (s0, s1, s2, s3, s4, s5, s6, s7): (u16, u16, u16, u16, u16, u16, u16, u16),
+            sp: u16,
+            (d0, d1, d2, d3, d4, d5, d6, d7): (u16, u16, u16, u16, u16, u16, u16, u16),
+            dp: u16,
         ) -> ProxyHeader {
             ProxyHeader::Version1 {
                 addresses: ProxyAddresses::Ipv6 {
-                    source: SocketAddrV6::new(Ipv6Addr::new(a, b, c, d, e, f, g, h), i, 0, 0),
-                    destination: SocketAddrV6::new(Ipv6Addr::new(j, k, l, m, n, o, p, q), r, 0, 0),
+                    source: SocketAddrV6::new(
+                        Ipv6Addr::new(s0, s1, s2, s3, s4, s5, s6, s7),
+                        sp,
+                        0,
+                        0,
+                    ),
+                    destination: SocketAddrV6::new(
+                        Ipv6Addr::new(d0, d1, d2, d3, d4, d5, d6, d7),
+                        dp,
+                        0,
+                        0,
+                    ),
                 },
             }
         }

--- a/src/version1.rs
+++ b/src/version1.rs
@@ -175,6 +175,8 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
     buf.advance(count);
 
     ensure!(buf.get_u8() == CR, IllegalHeaderEnding);
+    // We only checked up to the CR
+    ensure!(buf.remaining() >= 1, UnexpectedEof);
     ensure!(buf.get_u8() == LF, IllegalHeaderEnding);
 
     let addresses = match (source, destination) {

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -733,7 +733,7 @@ mod encode_tests {
                 ProxyTransportProtocol::Unspec,
                 ProxyAddresses::Unspec,
             ),
-            signed(&[(2 << 4) | 0, 0, 0, 0][..]),
+            signed(&[2 << 4, 0, 0, 0][..]),
         );
 
         assert_eq!(
@@ -756,7 +756,7 @@ mod encode_tests {
             signed(
                 &[
                     (2 << 4) | 1,
-                    (1 << 4) | 0,
+                    1 << 4,
                     0,
                     12,
                     1,
@@ -819,7 +819,7 @@ mod encode_tests {
             ),
             signed(
                 &[
-                    (2 << 4) | 0,
+                    2 << 4,
                     (1 << 4) | 2,
                     0,
                     12,
@@ -863,7 +863,7 @@ mod encode_tests {
             ),
             signed(
                 &[
-                    (2 << 4) | 0,
+                    2 << 4,
                     (2 << 4) | 2,
                     0,
                     36,

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -3,6 +3,7 @@ use snafu::{ensure, Snafu};
 use std::convert::TryInto;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
+
 #[derive(Debug, Snafu)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum ParseError {
@@ -140,14 +141,14 @@ trait Tlv: Sized {
 
     fn parse(buf: &mut impl Buf) -> Result<Self, ParseError> {
         if buf.remaining() < 3 {
-            return Err(ParseError::UnexpectedEof);
+            return UnexpectedEofSnafu.fail();
         }
         let type_id = buf.get_u8();
         let vlen = buf.get_u16();
         let expected_rem = buf
             .remaining()
             .checked_sub(vlen.into())
-            .ok_or(ParseError::UnexpectedEof)?;
+            .ok_or_else(|| ParseError::UnexpectedEof)?;
         let r = Self::parse_parts(type_id, vlen, buf)?;
         // Assert, because it would be an internal error
         assert_eq!(buf.remaining(), expected_rem);
@@ -231,7 +232,7 @@ impl Tlv for SslExtensionTlv {
             PP2_SUBTYPE_SSL_SIG_ALG => Self::Version(ascii_from_buf(buf, len)?),
             PP2_SUBTYPE_SSL_KEY_ALG => Self::Version(ascii_from_buf(buf, len)?),
             PP2_SUBTYPE_SSL_CN => Self::Version(str_from_buf(buf, len)?),
-            _ => return Err(ParseError::InvalidTlvTypeId { type_id }),
+            _ => return InvalidTlvTypeIdSnafu { type_id }.fail(),
         })
     }
 }
@@ -246,11 +247,11 @@ pub struct Ssl {
 impl Ssl {
     fn parse(buf: &mut impl Buf, len: u16) -> Result<Self, ParseError> {
         if buf.remaining() < len.into() {
-            return Err(ParseError::UnexpectedEof);
+            return UnexpectedEofSnafu.fail();
         }
         let mut ext_len = len
             .checked_sub(5)
-            .ok_or(ParseError::InsufficientLengthSpecified {
+            .ok_or_else(|| ParseError::InsufficientLengthSpecified {
                 given: len.into(),
                 needs: 5,
             })?;
@@ -272,7 +273,7 @@ impl Ssl {
             // new value is lower.
             ext_len = usize::from(ext_len)
                 .checked_sub(parsed)
-                .ok_or(ParseError::InsufficientLengthSpecified {
+                .ok_or_else(|| ParseError::InsufficientLengthSpecified {
                     given: ext_len.into(),
                     needs: parsed,
                 })?
@@ -398,7 +399,7 @@ impl Tlv for ExtensionTlv {
             PP2_TYPE_UNIQUE_ID => Self::UniqueId(vec_from_buf(buf, len)),
             PP2_TYPE_SSL => Self::Ssl(Ssl::parse(buf, len)?),
             PP2_TYPE_NETNS => Self::NetNs(ascii_from_buf(buf, len)?),
-            _ => return Err(ParseError::InvalidTlvTypeId { type_id }),
+            _ => return InvalidTlvTypeIdSnafu { type_id }.fail(),
         })
     }
 }
@@ -424,12 +425,12 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
     let command = match command {
         0 => ProxyCommand::Local,
         1 => ProxyCommand::Proxy,
-        cmd => return UnknownCommand { cmd }.fail(),
+        cmd => return UnknownCommandSnafu { cmd }.fail(),
     };
 
     // 4 bits for address family, 4 bits for transport protocol,
     // then 2 bytes for the length.
-    ensure!(buf.remaining() >= 3, UnexpectedEof);
+    ensure!(buf.remaining() >= 3, UnexpectedEofSnafu);
 
     let byte = buf.get_u8();
     let address_family = match byte >> 4 {
@@ -437,17 +438,17 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
         1 => ProxyAddressFamily::Inet,
         2 => ProxyAddressFamily::Inet6,
         3 => ProxyAddressFamily::Unix,
-        family => return UnknownAddressFamily { family }.fail(),
+        family => return UnknownAddressFamilySnafu { family }.fail(),
     };
     let transport_protocol = match byte << 4 >> 4 {
         0 => ProxyTransportProtocol::Unspec,
         1 => ProxyTransportProtocol::Stream,
         2 => ProxyTransportProtocol::Datagram,
-        protocol => return UnknownTransportProtocol { protocol }.fail(),
+        protocol => return UnknownTransportProtocolSnafu { protocol }.fail(),
     };
 
     let length = buf.get_u16() as usize;
-    ensure!(buf.remaining() >= length, UnexpectedEof);
+    ensure!(buf.remaining() >= length, UnexpectedEofSnafu);
 
     // Time to parse the following:
     //
@@ -481,12 +482,12 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
     if address_family == ProxyAddressFamily::Unix {
         ensure!(
             length >= 108 * 2,
-            InsufficientLengthSpecified {
+            InsufficientLengthSpecifiedSnafu {
                 given: length,
                 needs: 108usize * 2,
-            },
+            }
         );
-        ensure!(buf.remaining() >= length, UnexpectedEof);
+        ensure!(buf.remaining() >= length, UnexpectedEofSnafu);
         let mut source = [0u8; 108];
         let mut destination = [0u8; 108];
         buf.copy_to_slice(&mut source[..]);
@@ -500,11 +501,11 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
     let mut ext_len =
         length
             .checked_sub(address_len)
-            .ok_or(ParseError::InsufficientLengthSpecified {
+            .ok_or_else(|| ParseError::InsufficientLengthSpecified {
                 given: length,
                 needs: address_len,
             })?;
-    ensure!(buf.remaining() >= address_len, UnexpectedEof,);
+    ensure!(buf.remaining() >= address_len, UnexpectedEofSnafu,);
 
     let addresses = match address_family {
         ProxyAddressFamily::Unspec => ProxyAddresses::Unspec,
@@ -567,7 +568,7 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
             let skip_len = buf.get_u16();
             let noop_len = 3u16
                 .checked_add(skip_len)
-                .ok_or(ParseError::LengthOverflow {
+                .ok_or_else(|| ParseError::LengthOverflow {
                     given: skip_len.into(),
                 })?
                 .into();
@@ -586,7 +587,7 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
             ext_len =
                 ext_len
                     .checked_sub(parsed)
-                    .ok_or(ParseError::InsufficientLengthSpecified {
+                    .ok_or_else(|| ParseError::InsufficientLengthSpecified {
                         given: ext_len,
                         needs: parsed,
                     })?;
@@ -1085,7 +1086,7 @@ mod parse_tests {
     #[test]
     fn test_invalid_data() {
         let mut data = [0u8; 200];
-        rand::thread_rng().fill_bytes(&mut data);
+        rand::rng().fill_bytes(&mut data);
         data[0] = 99; // Make 100% sure it's invalid.
         assert!(parse_fully(&mut &data[..]).is_err());
 

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -1,5 +1,6 @@
 use bytes::{Buf, BufMut as _, BytesMut};
 use snafu::{ensure, Snafu};
+use std::convert::TryInto;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 #[derive(Debug, Snafu)]
@@ -494,6 +495,7 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
         if length > 108 * 2 {
             buf.advance(length - (108 * 2));
         }
+    }
 
     let mut ext_len =
         length

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -459,6 +459,23 @@ pub(crate) fn parse(buf: &mut impl Buf) -> Result<super::ProxyHeader, ParseError
         ProxyAddressFamily::Unix => 108 * 2,
         ProxyAddressFamily::Unspec => 0,
     };
+    if address_family == ProxyAddressFamily::Unix {
+        ensure!(
+            length >= 108 * 2,
+            InsufficientLengthSpecified {
+                given: length,
+                needs: 108usize * 2,
+            },
+        );
+        ensure!(buf.remaining() >= length, UnexpectedEof);
+        let mut source = [0u8; 108];
+        let mut destination = [0u8; 108];
+        buf.copy_to_slice(&mut source[..]);
+        buf.copy_to_slice(&mut destination[..]);
+        // TODO(Mariell Hoversholm): Support TLVs
+        if length > 108 * 2 {
+            buf.advance(length - (108 * 2));
+        }
 
     let mut ext_len =
         length

--- a/src/version2.rs
+++ b/src/version2.rs
@@ -1,7 +1,6 @@
 use bytes::{Buf, BufMut as _, BytesMut};
 use snafu::{ensure, Snafu};
-use std::convert::TryInto;
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 #[derive(Debug, Snafu)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
@@ -72,6 +71,25 @@ pub enum ProxyAddresses {
         source: [u8; 108],
         destination: [u8; 108],
     },
+}
+
+impl ProxyAddresses {
+    /// Construct IPv4 or IPv6 from given source and destination address.
+    ///
+    /// Returns `None` if the addresses use a different IP version.
+    pub fn from_socket_addrs(source: SocketAddr, destination: SocketAddr) -> Option<Self> {
+        match (source, destination) {
+            (SocketAddr::V4(source), SocketAddr::V4(destination)) => Some(Self::Ipv4 {
+                source,
+                destination,
+            }),
+            (SocketAddr::V6(source), SocketAddr::V6(destination)) => Some(Self::Ipv6 {
+                source,
+                destination,
+            }),
+            (_, _) => None,
+        }
+    }
 }
 
 #[derive(PartialEq, Eq)]


### PR DESCRIPTION
- Bump `snafu` dependency from version 0.6 to 0.8.
- Update `pretty_assertions` from version 0.7 to 1.4 and `rand` from version 0.8 to 0.9.
- Refactor error handling in the parsing functions to use Snafu error types for better clarity and consistency.
- Adjust tests to accommodate changes in the random number generation method.